### PR TITLE
chore: bump unreleased version to 0.1.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "binsize"
-version = "0.1.4"
+version = "0.1.5"
 description = "Tool to analyze the size of a binary from .elf file"
 license = "MIT"
 authors = [


### PR DESCRIPTION
After 0.1.4 release - https://pypi.org/project/binsize/